### PR TITLE
Disable refresh token cleanup service

### DIFF
--- a/Services/PasswordService.cs
+++ b/Services/PasswordService.cs
@@ -17,7 +17,7 @@ namespace Skrawl.API.Services
             argon2.Salt = salt;
             argon2.DegreeOfParallelism = 8;
             argon2.Iterations = 4;
-            argon2.MemorySize = 1024 * 1024;
+            argon2.MemorySize = 1024 * 128;
 
             return argon2.GetBytes(16);
         }

--- a/Startup.cs
+++ b/Startup.cs
@@ -96,7 +96,14 @@ namespace Skrawl.API
             });
 
             services.AddSingleton<IJwtAuthManager, JwtAuthManager>();
-            services.AddHostedService<JwtRefreshTokenCache>();
+
+            /** 
+             * TODO 
+             * Move refresh tokens to database, hitting Heroku's RAM limits
+             * Set more reasonable timers for the cleanup process
+             */
+            // services.AddHostedService<JwtRefreshTokenCache>();
+
             services.AddScoped<IPasswordService, PasswordService>();
             services.AddScoped<IUserService, UserService>();
 


### PR DESCRIPTION
Bring this user-actions branch up to date with master.

Disabled refresh token cleanup service because its implementation (in-memory) was causing the application to exceed server memory limits.

An issue will be opened to address this.